### PR TITLE
Default sorting AC + init dev branch

### DIFF
--- a/src/components/SearchControls/SearchControls.tsx
+++ b/src/components/SearchControls/SearchControls.tsx
@@ -76,7 +76,7 @@ export const SearchControls = ({
   const [zipInput, setZipInput] = useState(zipCode || "")
 
   useEffect(() => {
-    if (sortField === "breed" && selectedBreeds.length < 2) {
+    if (sortField === "breed" && selectedBreeds.length === 1) {
       onSortFieldChange("name")
     }
   }, [selectedBreeds.length, sortField, onSortFieldChange])
@@ -183,7 +183,7 @@ export const SearchControls = ({
               Sort: {sortFieldLabels[sortField] || "Name"}
             </MenuButton>
             <MenuList>
-              {selectedBreeds.length > 1 && (
+              {selectedBreeds.length !== 1 && (
                 <MenuItem onClick={() => onSortFieldChange("breed")}>
                   Breed
                 </MenuItem>


### PR DESCRIPTION
Changes:
- Per AC's, search results should be sorted alphabetically by `breed` by default. This hides the `breed` sorting option _only_ when 1 breed is selected from filter dropdown.
- Init dev branch